### PR TITLE
Fix V3005 warnings from PVS-Studio Static Analyzer

### DIFF
--- a/TaskEditor/TaskPropertiesControl.cs
+++ b/TaskEditor/TaskPropertiesControl.cs
@@ -1125,8 +1125,7 @@ namespace Microsoft.Win32.TaskScheduler
 			availableConnectionsCombo.Enabled = editable && v2 && taskStartIfConnectionCheck.Checked && !taskUseUnifiedSchedulingEngineCheck.Checked;
 			principalSIDTypeLabel.Enabled = principalSIDTypeCombo.Enabled = principalReqPrivilegesLabel.Enabled = 
 				principalReqPrivilegesDropDown.Enabled = taskDisallowStartOnRemoteAppSessionCheck.Enabled =
-				taskUseUnifiedSchedulingEngineCheck.Enabled = principalSIDTypeCombo.Enabled = principalReqPrivilegesDropDown.Enabled =
-				editable && v2_1;
+				taskUseUnifiedSchedulingEngineCheck.Enabled = editable && v2_1;
 			taskVolatileCheck.Enabled = taskMaintenanceDeadlineLabel.Enabled = taskMaintenanceDeadlineCombo.Enabled = 
 				taskMaintenanceExclusiveCheck.Enabled = taskMaintenancePeriodLabel.Enabled = taskMaintenancePeriodCombo.Enabled = editable && v2_2;
 		}


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug found using PVS-Studio. Warnings:

[V3005](https://www.viva64.com/en/w/v3005/) The 'principalSIDTypeCombo.Enabled' variable is assigned to itself. TaskPropertiesControl.cs 1126
[V3005](https://www.viva64.com/en/w/v3005/) The 'principalReqPrivilegesDropDown.Enabled' variable is assigned to itself. TaskPropertiesControl.cs 1127