### PR TITLE
Fix V3022 warnings from PVS-Studio Static Analyzer

### DIFF
--- a/TaskEditor/EventQueryList.cs
+++ b/TaskEditor/EventQueryList.cs
@@ -423,8 +423,7 @@ namespace Microsoft.Win32.TaskScheduler.Events
 					if (inner[0] != null)
 					{
 						newVal = Regex.Replace(inner[0], string.Join("|", new string[] { computer, evidrange, evid, keyword, level, prov, tasks, user, time2dates, timedate2end, timestart2date, timediff, AND, @"\s*\(\s*\)\s*", @"\s+" }), string.Empty, RegexOptions.IgnoreCase);
-						if (newVal != null)
-							newVal = Regex.Replace(newVal, @"\s*\(\s*(?:or\s*)*\)\s*", string.Empty, RegexOptions.IgnoreCase);
+						newVal = Regex.Replace(newVal, @"\s*\(\s*(?:or\s*)*\)\s*", string.Empty, RegexOptions.IgnoreCase);
 						ThrowIfBadXml(value, newVal, "Select");
 					}
 					if (inner[1] != null)

--- a/TaskEditor/TaskListView.cs
+++ b/TaskEditor/TaskListView.cs
@@ -172,8 +172,7 @@ namespace Microsoft.Win32.TaskScheduler
 				if (item != null)
 				{
 					item.Selected = true;
-					if (ContextMenuStrip != null)
-						ContextMenuStrip.Show(listView1, e.Location);
+					ContextMenuStrip.Show(listView1, e.Location);
 				}
 			}
 			OnMouseClick(e);

--- a/TaskService/Action.cs
+++ b/TaskService/Action.cs
@@ -998,7 +998,7 @@ namespace Microsoft.Win32.TaskScheduler
 		{
 			var sb = new System.Text.StringBuilder($"Start-Process -FilePath '{Path}'");
 			if (!string.IsNullOrEmpty(Arguments))
-				sb.Append($" -ArgumentList '{Arguments?.Replace("'", "''")}'");
+				sb.Append($" -ArgumentList '{Arguments.Replace("'", "''")}'");
 			if (!string.IsNullOrEmpty(WorkingDirectory))
 				sb.Append($" -WorkingDirectory '{WorkingDirectory}'");
 			return sb.Append("; ").ToString();


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug found using PVS-Studio. Warnings:

[V3022](https://www.viva64.com/en/w/v3022/) Expression 'newVal != null' is always true. EventQueryList.cs 426
[V3022](https://www.viva64.com/en/w/v3022/) Expression 'ContextMenuStrip != null' is always true. TaskListView.cs 175
[V3022](https://www.viva64.com/en/w/v3022/) Expression 'Arguments' is always not null. The operator '?.' is excessive. Action.cs 1001
