### PR TITLE
Fix V3115 warnings from PVS-Studio Static Analyzer

### DIFF
--- a/TaskEditor/DropDownCheckList.cs
+++ b/TaskEditor/DropDownCheckList.cs
@@ -487,6 +487,8 @@ namespace Microsoft.Win32.TaskScheduler
 		/// </exception>
 		public override bool Equals(object obj)
 		{
+            if (obj == null)
+                return false;
 			if (obj is DropDownCheckListItem)
 				return Text == ((DropDownCheckListItem)obj).Text && Value == ((DropDownCheckListItem)obj).Value;
 			if (obj.GetType() == Value.GetType())

--- a/TaskEditor/TaskOptionsEditor.cs
+++ b/TaskEditor/TaskOptionsEditor.cs
@@ -522,7 +522,9 @@ namespace Microsoft.Win32.TaskScheduler
 
 			public override bool Equals(object obj)
 			{
-				if (obj is ComboItem)
+                if (obj == null)
+                    return false;
+                if (obj is ComboItem)
 					return Version == ((ComboItem)obj).Version;
 				if (obj is int)
 					return Version == (int)obj;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug found using PVS-Studio. Warnings:

[V3115](https://www.viva64.com/en/w/v3115/) Passing 'null' to 'Equals' method should not result in 'NullReferenceException'. DropDownCheckList.cs 492
[V3115](https://www.viva64.com/en/w/v3115/) Passing 'null' to 'Equals' method should not result in 'NullReferenceException'. TaskOptionsEditor.cs 529