### PR TITLE
Fix V3063 warnings from PVS-Studio Static Analyzer

### DIFF
--- a/TaskEditor/Native/AccountUtils.cs
+++ b/TaskEditor/Native/AccountUtils.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Win32
 
 			public static bool CurrentUserIsAdmin(string computerName)
 			{
-				if (!string.IsNullOrEmpty(computerName) || computerName == ".")
+				if (!string.IsNullOrEmpty(computerName))
 					return true;
 
 				WindowsPrincipal principal = new WindowsPrincipal(WindowsIdentity.GetCurrent());

--- a/TaskService/TaskServiceCronExt.cs
+++ b/TaskService/TaskServiceCronExt.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Win32.TaskScheduler
 				ret.AddRange(ProcessCronTimes(cron, tr));
 			}
 			// DailyTrigger
-			else if (cron.Months.IsEvery && cron.DOW.IsEvery && cron.Days.repeating)
+			else if (cron.Months.IsEvery && cron.Days.repeating)
 			{
 				Trigger tr = new DailyTrigger((short)cron.Days.step);
 				ret.AddRange(ProcessCronTimes(cron, tr));

--- a/TaskService/User.cs
+++ b/TaskService/User.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Win32.TaskScheduler
 				acct = cur;
 				sid = acct.User;
 			}
-			else if (userName != null && userName.Contains("\\"))
+			else if (userName.Contains("\\"))
 			{
 				try
 				{


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug found using PVS-Studio. Warning:

[V3063](https://www.viva64.com/en/w/v3063/) A part of conditional expression is always false if it is evaluated: computerName == ".". AccountUtils.cs 91
[V3063](https://www.viva64.com/en/w/v3063/) A part of conditional expression is always true if it is evaluated: cron.DOW.IsEvery. TaskServiceCronExt.cs 109
[V3063](https://www.viva64.com/en/w/v3063/) A part of conditional expression is always true if it is evaluated: userName != null. User.cs 20