### PR TITLE
Fix V3108 warnings from PVS-Studio Static Analyzer

### DIFF
--- a/TaskEditor/EventQueryList.cs
+++ b/TaskEditor/EventQueryList.cs
@@ -780,7 +780,7 @@ namespace Microsoft.Win32.TaskScheduler.Events
 						else if (low.HasValue && high.HasValue)
 							return string.Concat(d1, " and ", d2);
 					}
-					return null;
+					return string.Empty;
 				}
 			}
 		}

--- a/TaskService/Native/NTDSAPI.cs
+++ b/TaskService/Native/NTDSAPI.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Win32
 			{
 				if (status == DS_NAME_ERROR.DS_NAME_NO_ERROR)
 					return pName;
-				return null;
+				return string.Empty;
 			}
 		}
 	}


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug found using PVS-Studio. Warnings:

[V3108](https://www.viva64.com/en/w/v3108/) It is not recommended to return 'null' from 'ToSting()' method. EventQueryList.cs 783
[V3108](https://www.viva64.com/en/w/v3108/) It is not recommended to return 'null' from 'ToSting()' method. NTDSAPI.cs 226