### PR TITLE
Fix V3031 warning from PVS-Studio Static Analyzer

### DIFF
--- a/TestTaskService/Native/ListViewExtensions.cs
+++ b/TestTaskService/Native/ListViewExtensions.cs
@@ -128,7 +128,7 @@ namespace System.Windows.Forms
 
 		public static void SetColumnDropDown(this ListView listView, int columnIndex, bool enable)
 		{
-			if (columnIndex < 0 || columnIndex >= 0 && listView.Columns == null || columnIndex >= listView.Columns.Count)
+			if (columnIndex < 0 || listView.Columns == null || columnIndex >= listView.Columns.Count)
 				throw new ArgumentOutOfRangeException(nameof(columnIndex));
 
 			if (listView.IsHandleCreated)


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug found using PVS-Studio. Warning:

[V3031](https://www.viva64.com/en/w/v3031/) An excessive check can be simplified. The '||' operator is surrounded by opposite expressions 'columnIndex < 0' and 'columnIndex >= 0'. ListViewExtensions.cs 131