### PR TITLE
Fix V3083 warnings from PVS-Studio Static Analyzer

### DIFF
--- a/TaskEditor/CustomComboBox.cs
+++ b/TaskEditor/CustomComboBox.cs
@@ -755,7 +755,7 @@ namespace Microsoft.Win32.TaskScheduler
 		{
 			EventHandler eventHandler = DropDown;
 			if (eventHandler != null)
-				DropDown(this, args);
+                eventHandler(this, args);
 		}
 
 		/// <summary>
@@ -766,7 +766,7 @@ namespace Microsoft.Win32.TaskScheduler
 		{
 			EventHandler eventHandler = DropDownClosed;
 			if (eventHandler != null)
-				DropDownClosed(this, args);
+                eventHandler(this, args);
 		}
 
 		/// <summary>


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug found using PVS-Studio. Warnings:

[V3083](https://www.viva64.com/en/w/v3083/) Unsafe invocation of event 'DropDown', NullReferenceException is possible. Consider assigning event to a local variable before invoking it. CustomComboBox.cs 758
[V3083](https://www.viva64.com/en/w/v3083/) Unsafe invocation of event 'DropDownClosed', NullReferenceException is possible. Consider assigning event to a local variable before invoking it. CustomComboBox.cs 769