### PR TITLE
Fix V3105 warning from PVS-Studio Static Analyzer

### DIFF
--- a/TaskEditor/SystemEventEnumerator.cs
+++ b/TaskEditor/SystemEventEnumerator.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Win32.TaskScheduler
 				Type elhType = session?.GetType().Assembly.GetType("System.Diagnostics.Eventing.Reader.EventLogHandle");
 				SessionHandlePI = session?.GetType().GetProperty("Handle", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic, null, elhType, Type.EmptyTypes, null);
 			}
-			object o = SessionHandlePI.GetValue(session, null);
+			object o = SessionHandlePI?.GetValue(session, null);
 			if (o != null)
 				hEvt = ((SafeHandle)o).DangerousGetHandle();
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug found using PVS-Studio. Warning:

[V3105](https://www.viva64.com/en/w/v3105/) The 'SessionHandlePI' variable was used after it was assigned through null-conditional operator. NullReferenceException is possible. SystemEventEnumerator.cs 94