### PR TITLE
Fix V3051 warning from PVS-Studio Static Analyzer

### DIFF
--- a/TaskEditor/DropDownCheckTree.cs
+++ b/TaskEditor/DropDownCheckTree.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Win32.TaskScheduler
 		public void CheckValue(string value, bool check = true)
 		{
 			TreeNode node;
-			if (value != null && value is string)
+			if (value != null)
 				if (values.TryGetValue((string)value, out node))
 					node.Checked = check;
 			UpdateText();


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug found using PVS-Studio. Warning:

[V3051](https://www.viva64.com/en/w/v3051/) An excessive type check. The object is already of the 'String' type. DropDownCheckTree.cs 119