### PR TITLE
Fix V3106 warnings from PVS-Studio Static Analyzer

### DIFF
--- a/TestTaskService/Program.cs
+++ b/TestTaskService/Program.cs
@@ -37,7 +37,7 @@ namespace TestTaskService
 				test = args[0].ToUpper()[0];
 				init++;
 			}
-			var newArgs = new[] { args.Length > init ? args[init] : "2", null, null, null, null };
+			var newArgs = new[] { args.Length > init ? args[init] : "2", null, null, null, null, null };
 			for (var i = init + 1; i < init + 5; i++)
 				if (args.Length > i) newArgs[i] = args[i];
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug found using PVS-Studio. Warnings:

[V3106](https://www.viva64.com/en/w/v3106/) Possibly index is out of bound. The value of 'i' index could reach 5. Program.cs 42
[V3106](https://www.viva64.com/en/w/v3106/) Possibly index is out of bound. The '5' index is pointing beyond 'newArgs' bound. Program.cs 56