### PR TITLE
Fix V3118

### DIFF
--- a/TaskEditor/CustomComboBox.cs
+++ b/TaskEditor/CustomComboBox.cs
@@ -797,7 +797,7 @@ namespace Microsoft.Win32.TaskScheduler
 						return;
 
 					case CBN_CLOSEUP:
-						if ((DateTime.Now - m_sShowTime).Seconds > 1)
+						if ((DateTime.Now - m_sShowTime).TotalSeconds > 1)
 							HideDropDown();
 						return;
 				}
@@ -810,7 +810,7 @@ namespace Microsoft.Win32.TaskScheduler
 		{
 			if (m_popupCtrl != null && m_popupCtrl.Visible)
 				HideDropDown();
-			else if ((DateTime.Now - m_lastHideTime).Milliseconds > 50)
+			else if ((DateTime.Now - m_lastHideTime).TotalMilliseconds > 50)
 				ShowDropDown();
 		}
 


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

- Seconds component of TimeSpan is used, which does not represent full time interval. Possibly 'TotalSeconds' value was intended instead. TaskEditor CustomComboBox.cs 800

- Milliseconds component of TimeSpan is used, which does not represent full time interval. Possibly 'TotalMilliseconds' value was intended instead. TaskEditor CustomComboBox.cs 813