### PR TITLE
Fixes ambiguous overload from #969

### DIFF
--- a/TaskService/TaskService.cs
+++ b/TaskService/TaskService.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Win32.TaskScheduler
 		/// The password that is used to connect to the computer as a SecureString. If the user name and securePassword are not specified, then the current token is used.
 		/// </param>
 		/// <param name="forceV1">If set to <c>true</c> force Task Scheduler 1.0 compatibility.</param>
-		public TaskService(string targetServer, [Optional] string userName, [Optional] string accountDomain, [Optional] SecureString userSecurePassword, bool forceV1 = false)
+		public TaskService(string targetServer, string userName, string accountDomain, SecureString userSecurePassword, bool forceV1 = false)
 		{
 			BeginInit();
 			TargetServer = targetServer;


### PR DESCRIPTION
The use of `[Optional]` attributes for each value causes an ambiguous overload error when using `new TaskService("Name")`.

If SecureString is desired then all ctor arguments are mandatory, this change causes selection of the original ctor if these values are not expressly provided.