### PR TITLE
Fix TaskSchedulerWizard.fr.resx

### DIFF
--- a/TaskEditor/TaskSchedulerWizard.fr.resx
+++ b/TaskEditor/TaskSchedulerWizard.fr.resx
@@ -142,7 +142,7 @@
     <value>Ouvrir les propriétés de cette tâche quand j’aurai cliqué sur Terminer</value>
   </data>
   <data name="openFileDialog1.Filter" xml:space="preserve">
-    <value>Tous les fichiers (*.*)</value>
+    <value>Tous les fichiers (*.*)|*.*</value>
   </data>
   <data name="repeatCheckBox.Text" xml:space="preserve">
     <value>Répéter la tâche toutes les :</value>


### PR DESCRIPTION
When trying to run the TaskSchedulerMockup on a French system, an exception is thrown:
![image](https://github.com/dahall/TaskScheduler/assets/7137528/7b806887-4a10-45f4-b74b-06aa405a96b2)

**System.Reflection.TargetInvocationException** : 'Une exception a été levée par la cible d'un appel.'
**ArgumentException** : La chaîne de filtre fournie n'est pas valide. La chaîne de filtre doit contenir une description du filtre, suivie d'une barre verticale (|) et du modèle du filtre. Les chaînes pour les différentes options de filtre doivent également être séparées par la barre verticale. Exemple : "Fichiers texte (*.txt)|*.txt|Tous les fichiers (*.*)|*.*"

The French translation is missing the pipe with the wildcard filter `|*.*`.