### PR TITLE
[Duplicated] Resolve EventLog Compatibility

### DIFF
--- a/TaskService/TaskService.csproj
+++ b/TaskService/TaskService.csproj
@@ -33,9 +33,24 @@
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
   </ItemGroup>
-  <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) And !$(TargetFramework.StartsWith('netcore')) ">
+  <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) And !$(TargetFramework.StartsWith('netcore')) And $(TargetFramework.StartsWith('net9')) ">
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Include="System.Diagnostics.EventLog" Version="9.0.0" />
+    <PackageReference Include="System.Security.AccessControl" Version="6.0.1" />
+  </ItemGroup>
+  <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) And !$(TargetFramework.StartsWith('netcore')) And $(TargetFramework.StartsWith('net8')) ">
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="System.Diagnostics.EventLog" Version="8.0.0" />
+    <PackageReference Include="System.Security.AccessControl" Version="6.0.1" />
+  </ItemGroup>
+  <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) And !$(TargetFramework.StartsWith('netcore')) And $(TargetFramework.StartsWith('net7')) ">
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Include="System.Diagnostics.EventLog" Version="7.0.0" />
+    <PackageReference Include="System.Security.AccessControl" Version="6.0.1" />
+  </ItemGroup>
+  <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) And !$(TargetFramework.StartsWith('netcore')) And $(TargetFramework.StartsWith('net6')) ">
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Include="System.Diagnostics.EventLog" Version="6.0.0" />
     <PackageReference Include="System.Security.AccessControl" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netcore')) ">

--- a/TaskService/TaskService.csproj
+++ b/TaskService/TaskService.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;net48;net6.0-windows;net7.0-windows;net8.0-windows;net9.0-windows;netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net45;net48;net6.0-windows;net7.0-windows;net8.0-windows;net9.0-windows</TargetFrameworks>
     <AssemblyName>Microsoft.Win32.TaskScheduler</AssemblyName>
     <RootNamespace>Microsoft.Win32.TaskScheduler</RootNamespace>
     <PackageId>TaskScheduler</PackageId>
@@ -32,11 +32,6 @@
     <PackageReference Include="System.Security.Permissions" Version="8.0.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) And !$(TargetFramework.StartsWith('netcore')) And $(TargetFramework.StartsWith('net9')) ">
-    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageReference Include="System.Diagnostics.EventLog" Version="9.0.0" />
-    <PackageReference Include="System.Security.AccessControl" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) And !$(TargetFramework.StartsWith('netcore')) And $(TargetFramework.StartsWith('net8')) ">
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />


### PR DESCRIPTION
Sorry for my misunderstanding of #1001. The solution should not be such simple.

After looking into related documents (https://stackoverflow.com/questions/74472659/exception-info-system-platformnotsupportedexception-eventlog-access-is-not-sup), I think this issue is related to the version of `System.Diagnostics.EventLog` package. We should specific EventLog package version for each .Net versions.