### PR TITLE
Resolve EventLog compatibility

### DIFF
--- a/TaskService/TaskService.csproj
+++ b/TaskService/TaskService.csproj
@@ -35,12 +35,12 @@
   </ItemGroup>
   <ItemGroup Condition=" !$(TargetFramework.StartsWith('netcore')) And $(TargetFramework.StartsWith('net9')) ">
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageReference Include="System.Diagnostics.EventLog" Version="8.0.0" />
+    <PackageReference Include="System.Diagnostics.EventLog" Version="9.0.2" />
     <PackageReference Include="System.Security.AccessControl" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup Condition=" !$(TargetFramework.StartsWith('netcore')) And $(TargetFramework.StartsWith('net8')) ">
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageReference Include="System.Diagnostics.EventLog" Version="8.0.0" />
+    <PackageReference Include="System.Diagnostics.EventLog" Version="8.0.1" />
     <PackageReference Include="System.Security.AccessControl" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup Condition=" !$(TargetFramework.StartsWith('netcore')) And $(TargetFramework.StartsWith('net7')) ">

--- a/TaskService/TaskService.csproj
+++ b/TaskService/TaskService.csproj
@@ -33,9 +33,29 @@
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
   </ItemGroup>
-  <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) And !$(TargetFramework.StartsWith('netcore')) ">
+  <ItemGroup Condition=" !$(TargetFramework.StartsWith('netcore')) And $(TargetFramework.StartsWith('net9')) ">
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="System.Diagnostics.EventLog" Version="8.0.0" />
+    <PackageReference Include="System.Security.AccessControl" Version="6.0.1" />
+  </ItemGroup>
+  <ItemGroup Condition=" !$(TargetFramework.StartsWith('netcore')) And $(TargetFramework.StartsWith('net8')) ">
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Include="System.Diagnostics.EventLog" Version="8.0.0" />
+    <PackageReference Include="System.Security.AccessControl" Version="6.0.1" />
+  </ItemGroup>
+  <ItemGroup Condition=" !$(TargetFramework.StartsWith('netcore')) And $(TargetFramework.StartsWith('net7')) ">
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Include="System.Diagnostics.EventLog" Version="7.0.0" />
+    <PackageReference Include="System.Security.AccessControl" Version="6.0.1" />
+  </ItemGroup>
+  <ItemGroup Condition=" !$(TargetFramework.StartsWith('netcore')) And $(TargetFramework.StartsWith('net6')) ">
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Include="System.Diagnostics.EventLog" Version="6.0.0" />
+    <PackageReference Include="System.Security.AccessControl" Version="6.0.1" />
+  </ItemGroup>
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Include="System.Diagnostics.EventLog" Version="6.0.0" />
     <PackageReference Include="System.Security.AccessControl" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netcore')) ">


### PR DESCRIPTION
Hello, firstly apologies for my misunderstanding of #1001. The solution should not be such simple.

After looking into related documents (https://stackoverflow.com/questions/74472659/exception-info-system-platformnotsupportedexception-eventlog-access-is-not-sup), I think this issue is related to the version of `System.Diagnostics.EventLog` package. We should specific EventLog package version for each .Net versions.

I have already tested in https://github.com/Flow-Launcher/Flow.Launcher/pull/3283 and now `TaskScheduler` works fine with our project based on .net7 and we are looking forward to your new version!